### PR TITLE
docs: add full node documentation and agent maintenance guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,140 @@
+## Documentation Maintenance
+
+This file describes when and how to update the documentation in `docs/` after making changes to the nodes.
+
+---
+
+## Source of Truth
+
+The nodes are defined in:
+
+| File | What it defines |
+|---|---|
+| `nodes/Worktables/Worktables.node.ts` | All resources, operations, parameters, and execution logic for the main Worktables node |
+| `nodes/Worktables/MondayWebhook.node.ts` | The Worktables Webhook trigger node |
+| `utils/worktablesHelpers.ts` | Column formatting helpers (affects output shape docs) |
+
+The documentation lives in `docs/`. The mapping between source and docs is:
+
+| Source change area | Doc file to update |
+|---|---|
+| `resource: 'board'` — any operation or field | `docs/board.md` |
+| `resource: 'item'` or `resource: 'subitem'` | `docs/item.md` |
+| `resource: 'update'` | `docs/update.md` |
+| `resource: 'team'` | `docs/team.md` |
+| `resource: 'user'` | `docs/user.md` |
+| `resource: 'notification'` | `docs/notification.md` |
+| `resource: 'query'` or `resource: 'downloadFile'` | `docs/query.md` |
+| `MondayWebhook.node.ts` | `docs/webhook.md` |
+| `columnType` options in `columnValues` | `docs/column-values.md` |
+| Adding/removing a resource or node | `docs/README.md` + the relevant resource file |
+
+---
+
+## When to Update Documentation
+
+Update docs whenever you make any of the following changes to a node:
+
+- **New operation added** — add a full section to the relevant resource file
+- **Operation removed or renamed** — remove or rename the section; update the operations table at the top of the file
+- **New parameter added** — add a row to the parameter table and update the JSON example for that operation
+- **Parameter removed** — remove the row and update the JSON example
+- **Parameter renamed** — update the key name in the parameter table and all JSON examples that reference it
+- **Parameter type changed** — update the Type column and any format notes
+- **Default value changed** — update the Default column
+- **New option added to an options/multiOptions field** — add the value to the options table or list in that section
+- **Option removed from an options field** — remove it from the table
+- **New column type supported** — add a full section to `docs/column-values.md`
+- **New resource added** — create a new doc file for it, add it to the table in `docs/README.md`
+- **Node renamed or new node added** — update `docs/README.md` and create/rename the relevant doc file
+- **Output shape changed** — update any output examples in the relevant doc file
+- **Webhook output format changed** — update `docs/webhook.md` output section
+
+---
+
+## Step-by-Step Process
+
+### 1. Identify what changed
+
+Read the diff carefully. For each changed property definition in the `properties` array of the node, note:
+- The `name` field — this is the JSON key used in `parameters`
+- The `displayName` — this is what the user sees in the UI (use it in the "Parameter" column of tables)
+- The `type` — string, number, boolean, options, multiOptions, fixedCollection, etc.
+- The `default` value
+- The `options` array (for options/multiOptions types)
+- The `displayOptions.show` conditions — determines which operation(s) this field belongs to
+
+### 2. Locate the right doc file
+
+Use the mapping table above. If a field appears under multiple operations that span different resources, update each relevant file.
+
+### 3. Update the operations table
+
+At the top of each resource doc file there is an operations table. If an operation was added or removed, update that table first.
+
+### 4. Update the parameter table
+
+Each operation section has a parameter table. Columns are:
+
+```
+| Parameter | Key | Type | Default | Notes |
+```
+
+- **Parameter** — the `displayName` from the node source
+- **Key** — the `name` from the node source (the JSON key used in `parameters`)
+- **Type** — the field type: `string`, `number`, `boolean`, `options`, `multiOptions`, `fixedCollection`, `dateTime`
+- **Default** — the `default` value from the source, formatted as inline code
+- **Notes** — constraints, dependencies, option values if short, or a cross-reference
+
+If a table has no Default column (simple operations), omit it rather than leaving it blank throughout.
+
+### 5. Update the JSON example
+
+Every operation section has at least one JSON example showing the `parameters` object. Rules:
+
+- Always show a **complete, runnable example** — include all required fields plus the most common optional ones
+- Omit fields that are `false`, `""`, or their default value only if they're truly rarely changed
+- If an operation has meaningfully different configurations (e.g. with and without subitems), show multiple examples with a heading above each
+- Use realistic-looking values (real-looking IDs, real column names) — do not use placeholder strings like `"YOUR_BOARD_ID"`
+- Keep the format consistent with existing examples: two-space indentation, string values in double quotes
+
+### 6. Update `docs/README.md` if needed
+
+Update `docs/README.md` when:
+- A new resource is added (update the "Node Reference" table)
+- A new node is added (update the "Available Nodes" table)
+- A new tip is relevant to multiple resources (add to Tips & Tricks)
+- A new common pitfall is found (add to Common Pitfalls)
+
+---
+
+## Style Conventions
+
+- **Option values** in tables: wrap in backtick code spans, e.g. `` `"public"` ``
+- **Parameter keys** in prose: wrap in backtick code spans, e.g. `` `boardId` ``
+- **Boolean defaults**: write as `` `false` `` or `` `true` ``
+- **"Required"** vs **"—"**: use "Required" in the Notes column only when the field is truly required by the node (`required: true` in source). Otherwise leave Notes blank or describe the condition.
+- **Blockquotes** (`>`) for warnings, edge cases, and important notes that don't fit in a table row
+- **Cross-references**: link to other doc files with relative markdown links, e.g. `[column-values.md](./column-values.md)`
+- Do not add emojis, decorative headers, or marketing language
+
+---
+
+## Checking Your Work
+
+After updating docs, verify:
+
+1. Every new `name` field in the node source appears as a **Key** in the parameter table of the right operation section
+2. Every removed field is gone from all parameter tables and JSON examples
+3. Every JSON example is valid JSON (no trailing commas, correct brackets)
+4. The operations table at the top of the file matches the actual available operations
+5. If you added a new resource file, it is listed in `docs/README.md`
+
+---
+
+## What NOT to Document Here
+
+- Internal implementation details (GraphQL query strings, helper function logic)
+- n8n platform behavior unrelated to these specific nodes
+- Anything already covered by the Monday.com API documentation
+- Credential setup steps (covered in `docs/README.md` — keep that section minimal)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,143 @@
+# Worktables n8n Nodes — Documentation
+
+This package provides two n8n nodes for interacting with **Monday.com** via its GraphQL API.
+
+---
+
+## Available Nodes
+
+| Node | Type | Description |
+|---|---|---|
+| `Worktables` | Action | Reads and writes data in Monday.com (boards, items, updates, teams, users, etc.) |
+| `Worktables Webhook` | Trigger | Receives Monday.com webhook events and optionally fetches the related item |
+
+---
+
+## Node Reference
+
+| File | Covers |
+|---|---|
+| [board.md](./board.md) | All Board resource operations |
+| [item.md](./item.md) | Item and Subitem resource operations, column value mapping |
+| [update.md](./update.md) | Update resource operations (create, edit, pin, upload) |
+| [team.md](./team.md) | Team resource operations |
+| [user.md](./user.md) | User resource operations |
+| [notification.md](./notification.md) | Sending notifications |
+| [query.md](./query.md) | Raw GraphQL API queries + file downloads |
+| [webhook.md](./webhook.md) | Worktables Webhook trigger node |
+| [column-values.md](./column-values.md) | Column type reference and JSON examples |
+
+---
+
+## Credentials
+
+Both nodes use the `WorktablesApi` credential, which requires a **Monday.com API token**.
+
+```json
+"credentials": {
+  "WorktablesApi": {
+    "id": "<credential-id>",
+    "name": "<credential-name>"
+  }
+}
+```
+
+The Webhook node can operate without credentials for raw event pass-through, but requires them if **Get Item After Event** is enabled.
+
+---
+
+## How Node JSON Parameters Work
+
+Every n8n node configuration follows this shape:
+
+```json
+{
+  "parameters": { ... },
+  "type": "@worktables/n8n-nodes-worktables.worktables",
+  "typeVersion": 1,
+  "position": [0, 0],
+  "id": "<uuid>",
+  "name": "My Node",
+  "credentials": {
+    "WorktablesApi": { "id": "...", "name": "..." }
+  }
+}
+```
+
+The `parameters` object is what changes per operation. Only `resource` and `operation` are required at minimum — all other fields fall back to their defaults when omitted.
+
+**Dynamic fields** (dropdowns loaded from the API) accept either the real ID as a string or an expression like `"=8886337654"`. Both forms work the same way at runtime.
+
+---
+
+## Tips & Tricks
+
+### Use expressions for dynamic IDs
+
+Any field that normally shows a dropdown can be overridden with an expression. Use `=` prefix to mark it as an expression:
+
+```json
+"boardId": "={{ $json.boardId }}"
+```
+
+### Comma-separated IDs
+
+Several filter fields accept multiple IDs as a comma-separated string:
+
+```json
+"columnIdsFilter": "status, date4, person",
+"itemIds": "1234567890, 9876543210"
+```
+
+### Limit 0 = fetch all
+
+Wherever a `limit` field exists, setting it to `0` tells the node to paginate automatically and return every record. Use with care on large boards.
+
+### Column IDs vs Column Titles
+
+The API always uses the **column ID** (e.g. `status`, `date4`, `text_mkq0ckhb`), not the display title. You can find the ID by using **Get a Board** or **List Board's Groups** and inspecting the `columns` array in the output.
+
+### Item vs Subitem
+
+Most item operations work for both items and subitems. The key toggle is `isSubitem`. When `true`:
+- `boardId` should point to the **parent board** (not the subitems board)
+- `parentId` identifies the parent item
+- Column options are loaded from the hidden subitems board automatically
+
+### createOrUpdateItem
+
+This is the most powerful item operation. Set an `identifierColumn` (any non-read-only column) and an `identifierValue`. If a matching item is found it will be updated; otherwise a new item is created. Leave `itemIdOptional` empty to always create.
+
+### searchItems filter rules
+
+Multiple rules are joined by the `logicalOperator` (`and`/`or`). Each rule targets one column. The `compareAttribute` field is optional and column-type-dependent (e.g. use `"text"` for status columns to compare against the label string).
+
+### Upload files
+
+- **uploadItemFile** uploads binary data to a `file`-type column on an item.
+- **uploadFile** (Update resource) attaches binary data to an update post.
+- Set `binaryPropertyName` / `attachmentsUpdate` to the n8n binary field name(s), comma-separated for multiple files.
+
+### Raw API Query
+
+When no built-in operation fits your need, use **Resource: Query → Run API**. You can write any Monday.com GraphQL query or mutation directly. Enable `includePagination` to auto-page cursor or page-based queries.
+
+### Webhook Challenge Handshake
+
+Monday.com sends a `challenge` field when first registering a webhook. The **Worktables Webhook** node handles this automatically — no action needed on your side.
+
+---
+
+## API Version
+
+The nodes use Monday.com API version `2026-01` by default. You can override this only in the **Query** resource via the `apiVersion` parameter.
+
+---
+
+## Common Pitfalls
+
+- **Board ID vs Workspace ID**: `boardId` and `workspace` are separate fields. Never pass a workspace ID as a board ID.
+- **Subitem board**: Subitems live on a separate hidden board (named "Subitems of …"). You do **not** need to know this board's ID — just use the parent board ID and set `isSubitem: true`.
+- **Status column values**: Status labels are stored by index internally. Use the `simple` column type with the label text (e.g. `"Done"`) and the node handles the conversion. Or use `objectValue` with `{ "label": "Done" }`.
+- **File columns**: Only `file`-type columns appear in the File Column dropdown for `uploadItemFile`. Other column types are filtered out.
+- **People column**: Accepts both users (`peopleValue`) and teams (`teamsValue`) in the same column entry.

--- a/docs/board.md
+++ b/docs/board.md
@@ -1,0 +1,381 @@
+# Board Resource
+
+**Resource value:** `"board"`
+
+All board-level operations: listing, creating, duplicating, managing groups, subscribers and activity logs.
+
+---
+
+## Operations
+
+| Operation | Value | Description |
+|---|---|---|
+| List Boards | `listBoards` | List all boards (default) |
+| List Board's Groups | `listBoardGroups` | List all groups in a board |
+| Get a Board | `getBoard` | Retrieve full board details |
+| Get a Group | `getGroup` | Retrieve a specific group |
+| Create a Board | `createBoard` | Create a new board |
+| Create a Group | `createGroup` | Add a group to a board |
+| Duplicate a Board | `duplicateBoard` | Copy an existing board |
+| Duplicate a Group | `duplicateGroup` | Copy a group within a board |
+| List Activity Logs | `listBoardActivityLogs` | Board-level activity feed |
+| List Board Subscribers | `listBoardSubscribers` | All subscribers of a board |
+| Add Board Subscribers | `addBoardSubscribers` | Subscribe users/teams to a board |
+| Remove Board Subscribers | `removeBoardSubscribers` | Unsubscribe users from a board |
+
+---
+
+## List Boards
+
+```json
+{
+  "parameters": {
+    "resource": "board",
+    "operation": "listBoards",
+    "boardKind": "all",
+    "state": "active",
+    "orderBy": "none",
+    "limit": 50,
+    "requestTimeout": 30000,
+    "filterByWorkspace": false
+  }
+}
+```
+
+| Parameter | Key | Type | Default | Notes |
+|---|---|---|---|---|
+| Board Kind | `boardKind` | options | `"all"` | `"all"` `"public"` `"private"` `"share"` |
+| Order By | `orderBy` | options | `"none"` | `"none"` `"created_at"` `"used_at"` |
+| State | `state` | options | `"active"` | `"all"` `"active"` `"archived"` `"deleted"` |
+| Limit | `limit` | number | `50` | `0` = all boards |
+| Request Timeout (ms) | `requestTimeout` | number | `30000` | Increase for large accounts |
+| Filter by Workspace | `filterByWorkspace` | boolean | `false` | Enables workspace filter |
+| Workspace | `workspace` | options/string | — | Required when `filterByWorkspace: true` |
+
+**With workspace filter:**
+```json
+{
+  "parameters": {
+    "resource": "board",
+    "operation": "listBoards",
+    "boardKind": "public",
+    "state": "active",
+    "limit": 0,
+    "filterByWorkspace": true,
+    "workspace": "2425174"
+  }
+}
+```
+
+---
+
+## List Board's Groups
+
+```json
+{
+  "parameters": {
+    "resource": "board",
+    "operation": "listBoardGroups",
+    "workspace": "-1",
+    "boardId": "6414507323",
+    "archiveGroup": false,
+    "deleteGroup": false
+  }
+}
+```
+
+| Parameter | Key | Type | Default | Notes |
+|---|---|---|---|---|
+| Workspace | `workspace` | options/string | — | Required |
+| Board | `boardId` | options/string | — | Required |
+| Archived | `archiveGroup` | boolean | `false` | Include archived groups in result |
+| Deleted | `deleteGroup` | boolean | `false` | Include deleted groups in result |
+
+---
+
+## Get a Board
+
+Returns board details including columns, groups, subscribers and workspace.
+
+```json
+{
+  "parameters": {
+    "resource": "board",
+    "operation": "getBoard",
+    "boardId": "8886337654"
+  }
+}
+```
+
+| Parameter | Key | Type | Notes |
+|---|---|---|---|
+| Board | `boardId` | options/string | Required |
+
+---
+
+## Get a Group
+
+```json
+{
+  "parameters": {
+    "resource": "board",
+    "operation": "getGroup",
+    "boardId": "8886337654",
+    "groupId": "topics"
+  }
+}
+```
+
+| Parameter | Key | Type | Notes |
+|---|---|---|---|
+| Board | `boardId` | options/string | Required |
+| Group ID | `groupId` | options/string | Required |
+
+---
+
+## Create a Board
+
+```json
+{
+  "parameters": {
+    "resource": "board",
+    "operation": "createBoard",
+    "workspace": "2425174",
+    "boardName": "My New Board",
+    "boardKind": "public",
+    "description": "Created via n8n",
+    "templateId": "",
+    "folder": "16952074",
+    "usersBoardIds": {
+      "usersBoardIds": [
+        { "userId": "61864800", "isOwner": true }
+      ]
+    },
+    "teamBoardIds": {
+      "teamBoardIds": [
+        { "teamId": "952718", "isOwner": false }
+      ]
+    }
+  }
+}
+```
+
+| Parameter | Key | Type | Default | Notes |
+|---|---|---|---|---|
+| Workspace | `workspace` | options/string | — | Required |
+| New Board Name | `boardName` | string | — | Board display name |
+| Board Kind | `boardKind` | options | `"public"` | `"public"` `"private"` `"share"` |
+| Description | `description` | string | — | Optional description |
+| Template ID | `templateId` | string | — | Monday.com template ID |
+| Folder ID | `folder` | options/string | — | Required; use `"-1"` for no folder |
+| User Subscribers | `usersBoardIds` | fixedCollection | — | List of `{ userId, isOwner }` |
+| Team Subscribers | `teamBoardIds` | fixedCollection | — | List of `{ teamId, isOwner }` |
+
+---
+
+## Create a Group
+
+```json
+{
+  "parameters": {
+    "resource": "board",
+    "operation": "createGroup",
+    "boardId": "8886337654",
+    "groupName": "New Group",
+    "groupColor": "#00c875",
+    "groupId": "topics",
+    "positionRelative": "after_at"
+  }
+}
+```
+
+| Parameter | Key | Type | Default | Notes |
+|---|---|---|---|---|
+| Board | `boardId` | options/string | — | Required |
+| Group Name | `groupName` | string | — | Display name |
+| Group Color | `groupColor` | options | `"#c4c4c4"` | See color options below |
+| Relative To Group | `groupId` | options/string | — | Anchor group for positioning |
+| Position Relative | `positionRelative` | options | `"before_at"` | `"before_at"` or `"after_at"` |
+
+**Available colors:**
+
+| Name | Hex |
+|---|---|
+| Grey | `#c4c4c4` |
+| Working Orange | `#fdab3d` |
+| Done Green | `#00c875` |
+| Stuck Red | `#e2445c` |
+| Dark Blue | `#0086c0` |
+| Purple | `#a25ddc` |
+| Grass Green | `#037f4c` |
+| Bright Blue | `#579bfc` |
+| Saladish | `#cab641` |
+| Egg Yolk | `#ffcb00` |
+| Dark Red | `#bb3354` |
+| Sofia Pink | `#ff158a` |
+| Lipstick | `#ff5ac4` |
+| Dark Purple | `#784bd1` |
+| Bright Green | `#9cd326` |
+| Chili Blue | `#66ccff` |
+| American Grey | `#808080` |
+| Brown | `#7f5347` |
+| Dark Orange | `#ff642e` |
+
+---
+
+## Duplicate a Board
+
+```json
+{
+  "parameters": {
+    "resource": "board",
+    "operation": "duplicateBoard",
+    "boardId": "8886337654",
+    "workspace": "2425174",
+    "folder": "16952074",
+    "boardName": "Duplicated by n8n",
+    "keepSubscribers": true,
+    "duplicateType": "duplicate_board_with_structure"
+  }
+}
+```
+
+| Parameter | Key | Type | Default | Notes |
+|---|---|---|---|---|
+| Board to Duplicate | `boardId` | options/string | — | Source board |
+| Destination Workspace | `workspace` | options/string | — | Required |
+| Destination Folder | `folder` | options/string | — | Required; use `"-1"` for none |
+| New Board Name | `boardName` | string | — | Name for the copy |
+| Keep Subscribers | `keepSubscribers` | boolean | `false` | Copy subscriber list |
+| Duplicate Type | `duplicateType` | options | `"duplicate_board_with_structure"` | See below |
+
+**Duplicate type options:**
+
+| Value | Description |
+|---|---|
+| `duplicate_board_with_structure` | Copy structure only (no items) |
+| `duplicate_board_with_pulses` | Copy structure + items |
+| `duplicate_board_with_pulses_and_updates` | Copy structure + items + updates |
+
+---
+
+## Duplicate a Group
+
+```json
+{
+  "parameters": {
+    "resource": "board",
+    "operation": "duplicateGroup",
+    "boardId": "8886337654",
+    "groupId": "topics",
+    "groupName": "Duplicated Group",
+    "addToTop": false
+  }
+}
+```
+
+| Parameter | Key | Type | Default | Notes |
+|---|---|---|---|---|
+| Board | `boardId` | options/string | — | Required |
+| Group | `groupId` | options/string | — | Group to duplicate |
+| Group Name | `groupName` | string | — | Name for the copy |
+| Add to Top | `addToTop` | boolean | `false` | Place copy at the top of the board |
+
+---
+
+## List Activity Logs
+
+```json
+{
+  "parameters": {
+    "resource": "board",
+    "operation": "listBoardActivityLogs",
+    "boardId": "8886337654",
+    "from": "2025-04-08T00:00:00",
+    "to": "2025-04-09T14:44:51",
+    "limit": 50,
+    "itemIds": "8886337853, 8886337925",
+    "columnIdsFilter": "status, date4",
+    "groupIdsFilter": "topics",
+    "userIdsFilter": ["45779868"]
+  }
+}
+```
+
+| Parameter | Key | Type | Default | Notes |
+|---|---|---|---|---|
+| Board | `boardId` | options/string | — | Required |
+| From | `from` | dateTime | — | Inclusive start datetime |
+| To | `to` | dateTime | — | Inclusive end datetime |
+| Limit | `limit` | number | `50` | `0` = all logs |
+| Item IDs | `itemIds` | string | — | Comma-separated item IDs |
+| Column IDs | `columnIdsFilter` | string | — | Comma-separated column IDs |
+| Group IDs | `groupIdsFilter` | string | — | Comma-separated group IDs |
+| User IDs | `userIdsFilter` | multiOptions | `[]` | Selected users |
+
+---
+
+## List Board Subscribers
+
+```json
+{
+  "parameters": {
+    "resource": "board",
+    "operation": "listBoardSubscribers",
+    "boardId": "8886337654"
+  }
+}
+```
+
+Returns both user subscribers and team subscribers with full profile details.
+
+---
+
+## Add Board Subscribers
+
+```json
+{
+  "parameters": {
+    "resource": "board",
+    "operation": "addBoardSubscribers",
+    "boardId": "8886337654",
+    "usersBoardIds": {
+      "usersBoardIds": [
+        { "userId": "35597267", "isOwner": false },
+        { "userId": "61864800", "isOwner": true }
+      ]
+    },
+    "teamBoardIds": {
+      "teamBoardIds": [
+        { "teamId": "952709", "isOwner": false }
+      ]
+    }
+  }
+}
+```
+
+| Parameter | Key | Type | Notes |
+|---|---|---|---|
+| Board | `boardId` | options/string | Required |
+| User Subscribers | `usersBoardIds` | fixedCollection | `{ userId, isOwner }` entries |
+| Team Subscribers | `teamBoardIds` | fixedCollection | `{ teamId, isOwner }` entries |
+
+---
+
+## Remove Board Subscribers
+
+```json
+{
+  "parameters": {
+    "resource": "board",
+    "operation": "removeBoardSubscribers",
+    "boardId": "8886337654",
+    "removeSubscribers": ["71503960", "35597267"]
+  }
+}
+```
+
+| Parameter | Key | Type | Notes |
+|---|---|---|---|
+| Board | `boardId` | options/string | Required |
+| Remove Subscribers | `removeSubscribers` | multiOptions | Array of user IDs |

--- a/docs/column-values.md
+++ b/docs/column-values.md
@@ -1,0 +1,399 @@
+# Column Values Reference
+
+This file covers how to set column values when using **Create an Item**, **Update Column Values**, and **Create or Update Item** operations.
+
+Column values are configured inside the `columnValues.column` array. Each entry sets one column.
+
+---
+
+## Column entry structure
+
+```json
+{
+  "columnId": "<column-id>",
+  "columnType": "<type>",
+  ... type-specific fields ...
+}
+```
+
+- `columnId` — the internal column ID (e.g. `"status"`, `"date4"`, `"text_mkq0ckhb"`). Find IDs via **Get a Board** or **List Board's Groups**.
+- `columnType` — controls which input fields appear and how the value is sent to the API.
+
+---
+
+## Column Types
+
+| Type Value | Description |
+|---|---|
+| `simple` | Plain string — works for text, numbers, status labels |
+| `objectValue` | Raw JSON object for full control |
+| `date` | Date/datetime picker |
+| `checkbox` | Boolean checkbox |
+| `people` | Assign users and/or teams |
+| `link` | URL + display text |
+| `email` | Email address + display text |
+| `phone` | Phone number + country code |
+| `location` | Latitude, longitude, and address |
+| `timeline` | Start and end date range |
+| `board_relation` | Connect Boards — link item IDs from another board |
+| `fileLink` | Add file links by URL |
+| `button` | Trigger a button click |
+
+---
+
+## simple
+
+Sends a plain string value. Monday.com interprets it based on the column type:
+- **Text columns**: stored as-is
+- **Number columns**: numeric string
+- **Status columns**: the label text (e.g. `"Done"`, `"In Progress"`)
+
+```json
+{
+  "columnId": "status",
+  "columnType": "simple",
+  "columnValue": "Done"
+}
+```
+
+```json
+{
+  "columnId": "numbers",
+  "columnType": "simple",
+  "columnValue": "42"
+}
+```
+
+| Field | Key | Type |
+|---|---|---|
+| Value | `columnValue` | string |
+
+---
+
+## objectValue
+
+Full JSON object sent directly to the Monday.com API. Use when you need fine-grained control or for column types not covered by specific options.
+
+```json
+{
+  "columnId": "status",
+  "columnType": "objectValue",
+  "objectValue": { "label": "Done" }
+}
+```
+
+```json
+{
+  "columnId": "dropdown",
+  "columnType": "objectValue",
+  "objectValue": { "ids": [1, 2] }
+}
+```
+
+| Field | Key | Type |
+|---|---|---|
+| Column Value | `objectValue` | JSON |
+
+> Accepts either a JSON literal or an n8n expression: `"={{ $json.columnPayload }}"`
+
+---
+
+## date
+
+```json
+{
+  "columnId": "date4",
+  "columnType": "date",
+  "dateValue": "2025-06-01T00:00:00"
+}
+```
+
+| Field | Key | Type | Notes |
+|---|---|---|---|
+| Date | `dateValue` | dateTime | ISO 8601 format |
+
+---
+
+## checkbox
+
+```json
+{
+  "columnId": "checkbox",
+  "columnType": "checkbox",
+  "checkboxValue": true
+}
+```
+
+| Field | Key | Type | Notes |
+|---|---|---|---|
+| Checked | `checkboxValue` | boolean | `true` = checked, `false` = unchecked |
+
+---
+
+## people
+
+Assign users and/or teams to a People column. Both arrays can be used together.
+
+```json
+{
+  "columnId": "person",
+  "columnType": "people",
+  "peopleValue": ["45779868", "35597267"],
+  "teamsValue": ["952718"]
+}
+```
+
+| Field | Key | Type | Notes |
+|---|---|---|---|
+| People | `peopleValue` | multiOptions | User IDs to assign |
+| Teams | `teamsValue` | multiOptions | Team IDs to assign |
+
+---
+
+## link
+
+```json
+{
+  "columnId": "link",
+  "columnType": "link",
+  "url": "https://example.com",
+  "linkText": "Visit Site"
+}
+```
+
+| Field | Key | Type | Notes |
+|---|---|---|---|
+| URL | `url` | string | The destination URL |
+| Text | `linkText` | string | Display label for the link |
+
+---
+
+## email
+
+```json
+{
+  "columnId": "email",
+  "columnType": "email",
+  "emailValue": "user@example.com",
+  "emailText": "Contact Us"
+}
+```
+
+| Field | Key | Type | Notes |
+|---|---|---|---|
+| Email | `emailValue` | string | Email address |
+| Text | `emailText` | string | Optional display label; defaults to the address |
+
+---
+
+## phone
+
+```json
+{
+  "columnId": "phone",
+  "columnType": "phone",
+  "countryCode": "US",
+  "phoneValue": "5551234567"
+}
+```
+
+| Field | Key | Type | Notes |
+|---|---|---|---|
+| Country Code | `countryCode` | options | Select from list (e.g. `"US"`, `"BR"`, `"GB"`) |
+| Phone | `phoneValue` | string | Number only — **no country code prefix** |
+
+---
+
+## location
+
+```json
+{
+  "columnId": "location",
+  "columnType": "location",
+  "latitude": "-23.5505",
+  "longitude": "-46.6333",
+  "address": "São Paulo, Brazil"
+}
+```
+
+| Field | Key | Type |
+|---|---|---|
+| Latitude | `latitude` | string |
+| Longitude | `longitude` | string |
+| Address | `address` | string |
+
+---
+
+## timeline
+
+Sets a date range (start → end) for a Timeline column.
+
+```json
+{
+  "columnId": "timeline",
+  "columnType": "timeline",
+  "startDate": "2025-06-01T00:00:00",
+  "endDate": "2025-06-30T00:00:00"
+}
+```
+
+| Field | Key | Type |
+|---|---|---|
+| Start Date | `startDate` | dateTime |
+| End Date | `endDate` | dateTime |
+
+---
+
+## board_relation (Connect Boards)
+
+Links items from another board to this column.
+
+```json
+{
+  "columnId": "connect_boards",
+  "columnType": "board_relation",
+  "columnValue": "1234567890, 9876543210",
+  "addConnections": false
+}
+```
+
+| Field | Key | Type | Default | Notes |
+|---|---|---|---|---|
+| Connect Boards | `columnValue` | string | — | Comma-separated item IDs from the connected board |
+| Add instead of replacing | `addConnections` | boolean | `false` | `false` = replace all; `true` = append to existing |
+
+---
+
+## fileLink
+
+Adds a file reference by URL (does not upload — the file must be publicly accessible).
+
+```json
+{
+  "columnId": "files_mkkqsvnw",
+  "columnType": "fileLink",
+  "fileLinks": {
+    "file": [
+      {
+        "linkToFile": "https://example.com/report.pdf",
+        "name": "report.pdf"
+      },
+      {
+        "linkToFile": "https://example.com/data.csv",
+        "name": "data.csv"
+      }
+    ]
+  }
+}
+```
+
+| Field | Key | Type | Notes |
+|---|---|---|---|
+| Files | `fileLinks` | fixedCollection | Array of file objects |
+| Link | `linkToFile` | string | Direct URL to the file |
+| Name | `name` | string | Display name for the file |
+
+> To **upload** binary files (not links), use the **Upload Files to Column** operation instead.
+
+---
+
+## button
+
+Triggers a button click on a Button column.
+
+```json
+{
+  "columnId": "button",
+  "columnType": "button",
+  "buttonValue": true
+}
+```
+
+| Field | Key | Type |
+|---|---|---|
+| Click | `buttonValue` | boolean |
+
+---
+
+## Complete columnValues example
+
+Multiple columns set in one operation:
+
+```json
+{
+  "columnValues": {
+    "column": [
+      {
+        "columnId": "status",
+        "columnType": "simple",
+        "columnValue": "Done"
+      },
+      {
+        "columnId": "date4",
+        "columnType": "date",
+        "dateValue": "2025-06-15T00:00:00"
+      },
+      {
+        "columnId": "person",
+        "columnType": "people",
+        "peopleValue": ["45779868"],
+        "teamsValue": []
+      },
+      {
+        "columnId": "link_mkq",
+        "columnType": "link",
+        "url": "https://example.com",
+        "linkText": "Reference"
+      },
+      {
+        "columnId": "timeline",
+        "columnType": "timeline",
+        "startDate": "2025-06-01T00:00:00",
+        "endDate": "2025-06-30T00:00:00"
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Finding column IDs
+
+Column IDs are **not** the display titles. To find them:
+
+1. Use **Get a Board** (`resource: board, operation: getBoard`) — the response includes a `columns` array with `id` and `title`.
+2. Use **List Board's Groups** — same `columns` data in the output.
+3. Use the **Query** resource: `{ boards(ids: [YOUR_BOARD_ID]) { columns { id title type } } }`
+
+Common default column IDs:
+
+| Title | ID |
+|---|---|
+| Name | `name` |
+| Status | `status` |
+| Person | `person` |
+| Date | `date4` |
+| Timeline | `timeline` |
+| Files | varies (`files_*`) |
+| Numbers | `numbers` |
+| Text | varies (`text_*`) |
+
+> Custom columns always have a generated suffix like `text_mkq0ckhb`. These IDs are stable and won't change when you rename the column.
+
+---
+
+## Read-only columns (cannot be set)
+
+These column types are excluded from the column picker and cannot be written:
+
+| Type | Notes |
+|---|---|
+| `formula` | Computed — read only |
+| `auto_number` | Auto-incremented |
+| `creation_log` | Set by Monday on creation |
+| `last_updated` | Updated by Monday automatically |
+| `mirror` | Reflects another board |
+| `subtasks` | Managed by subitems system |
+| `item_id` | The item's own ID |
+| `progress` | Computed from subitems |

--- a/docs/item.md
+++ b/docs/item.md
@@ -1,0 +1,485 @@
+# Item & Subitem Resource
+
+**Resource value:** `"item"` (or `"subitem"` for the legacy createSubitem operation)
+
+Items are the rows of a Monday.com board. Subitems are child rows attached to a parent item. Most item operations support both by toggling `isSubitem`.
+
+See [column-values.md](./column-values.md) for a full reference on how to set every column type.
+
+---
+
+## Operations
+
+| Operation | Value | Description |
+|---|---|---|
+| Get an Item | `getItem` | Fetch a single item by ID |
+| Create an Item | `createItem` | Create a new item (default) |
+| Update Column Values | `updateItem` | Update columns on an existing item |
+| Create or Update Item | `createOrUpdateItem` | Upsert by identifier column |
+| Delete an Item | `deleteItem` | Permanently delete an item |
+| Duplicate an Item | `duplicateItem` | Copy an item |
+| List Items in a Board | `listBoardItems` | Paginated item list for a board |
+| List Items in a Group | `listGroupItems` | Paginated item list for a group |
+| Search Items by Filter | `searchItems` | Filter + sort items |
+| List Item Subscribers | `listItemSubscribers` | Users subscribed to an item |
+| Get Item Activity Logs | `getItemActivityLogs` | Activity feed for a single item |
+| Upload Files to Column | `uploadItemFile` | Upload binary file to a file column |
+
+---
+
+## Get an Item
+
+Fetches a single item by its ID with formatted column values.
+
+```json
+{
+  "parameters": {
+    "resource": "item",
+    "operation": "getItem",
+    "itemId": "8886337853",
+    "isSubitem": false,
+    "fetchSubitems": false,
+    "fetchAllColumns": true
+  }
+}
+```
+
+| Parameter | Key | Type | Default | Notes |
+|---|---|---|---|---|
+| Item ID | `itemId` | string | — | Required |
+| Is Subitem | `isSubitem` | boolean | `false` | Treat as subitem |
+| Fetch Subitems | `fetchSubitems` | boolean | `false` | Include child subitems (when not a subitem) |
+| Fetch Parent Item | `fetchParentItems` | boolean | `false` | Include parent item data (when a subitem) |
+| Fetch All Columns | `fetchAllColumns` | boolean | `true` | All columns vs specific ones |
+| Column IDs | `columnIds` | string | — | Comma-separated, used when `fetchAllColumns: false` |
+
+**Fetch specific columns only:**
+```json
+{
+  "parameters": {
+    "resource": "item",
+    "operation": "getItem",
+    "itemId": "8886337853",
+    "fetchAllColumns": false,
+    "columnIds": "status, date4, person"
+  }
+}
+```
+
+**Get a subitem and its parent:**
+```json
+{
+  "parameters": {
+    "resource": "item",
+    "operation": "getItem",
+    "itemId": "8886340579",
+    "isSubitem": true,
+    "fetchParentItems": true,
+    "fetchAllColumns": true
+  }
+}
+```
+
+### Output shape
+
+```json
+{
+  "id": "8886337853",
+  "name": "Item Name",
+  "created_at": "2025-01-01T00:00:00Z",
+  "updated_at": "2025-01-02T00:00:00Z",
+  "group": {
+    "id": "topics",
+    "title": "Topics",
+    "color": "#579bfc",
+    "position": "0"
+  },
+  "column_values": {
+    "status": { "type": "color", "value": { "index": 1 }, "text": "Done" },
+    "date4":  { "type": "date",  "value": { "date": "2025-06-01" }, "text": "2025-06-01" },
+    "person": { "type": "people", "value": { "personsAndTeams": [...] }, "text": "Alice" }
+  }
+}
+```
+
+---
+
+## Create an Item
+
+```json
+{
+  "parameters": {
+    "resource": "item",
+    "operation": "createItem",
+    "boardId": "8886337654",
+    "isSubitem": false,
+    "groupId": "group_mkpva8wm",
+    "itemName": "New Item",
+    "columnValues": {
+      "column": [
+        {
+          "columnId": "status",
+          "columnType": "simple",
+          "columnValue": "Done"
+        }
+      ]
+    }
+  }
+}
+```
+
+| Parameter | Key | Type | Notes |
+|---|---|---|---|
+| Board | `boardId` | options/string | Required |
+| Is Subitem? | `isSubitem` | boolean | Toggle to create a subitem instead |
+| Group | `groupId` | options/string | Required when `isSubitem: false` |
+| Parent Item | `parentId` | options/string | Required when `isSubitem: true` |
+| Item Name | `itemName` | string | Display name for the item |
+| Column Values | `columnValues` | fixedCollection | See [column-values.md](./column-values.md) |
+
+**Create a subitem:**
+```json
+{
+  "parameters": {
+    "resource": "item",
+    "operation": "createItem",
+    "boardId": "8886337654",
+    "isSubitem": true,
+    "parentId": "8886337853",
+    "itemName": "New Subitem",
+    "columnValues": { "column": [] }
+  }
+}
+```
+
+---
+
+## Update Column Values of an Item
+
+Updates one or more column values on an existing item or subitem.
+
+```json
+{
+  "parameters": {
+    "resource": "item",
+    "operation": "updateItem",
+    "boardId": "8886337654",
+    "itemId": "8886337853",
+    "columnValues": {
+      "column": [
+        {
+          "columnId": "status",
+          "columnType": "simple",
+          "columnValue": "In Progress"
+        },
+        {
+          "columnId": "date4",
+          "columnType": "date",
+          "dateValue": "2025-06-01T00:00:00"
+        }
+      ]
+    }
+  }
+}
+```
+
+| Parameter | Key | Type | Notes |
+|---|---|---|---|
+| Board | `boardId` | options/string | Required |
+| Item | `itemId` | options/string | Required — item to update |
+| Column Values | `columnValues` | fixedCollection | See [column-values.md](./column-values.md) |
+
+---
+
+## Create or Update Item (Upsert)
+
+Searches for an existing item using an identifier column and either updates it or creates a new one.
+
+```json
+{
+  "parameters": {
+    "resource": "item",
+    "operation": "createOrUpdateItem",
+    "boardId": "8886337654",
+    "isSubitem": false,
+    "identifierColumn": "text_mkq0ckhb",
+    "itemIdOptional": "my-unique-key",
+    "itemName": "Upserted Item",
+    "groupName": "topics",
+    "columnValues": {
+      "column": [
+        {
+          "columnId": "status",
+          "columnType": "simple",
+          "columnValue": "Done"
+        }
+      ]
+    }
+  }
+}
+```
+
+| Parameter | Key | Type | Notes |
+|---|---|---|---|
+| Board | `boardId` | options/string | Required |
+| Is Subitem? | `isSubitem` | boolean | Work with subitems |
+| Identifier Column | `identifierColumn` | options | Column used to look up the item |
+| Identifier Value | `itemIdOptional` | string | Value to match; leave empty to always create |
+| Item Name | `itemName` | string | Name for create or rename on update |
+| Group Name | `groupName` | options/string | Group for new items (when `isSubitem: false`) |
+| Parent Item | `parentId` | options/string | Parent for new subitems (when `isSubitem: true`) |
+| Column Values | `columnValues` | fixedCollection | Applied on both create and update |
+
+**How it works:**
+1. If `itemIdOptional` is empty → always creates a new item
+2. If `itemIdOptional` has a value → searches the board for an item where `identifierColumn` matches that value
+3. Match found → update that item's column values
+4. No match → create a new item
+
+> Read-only column types (formula, auto_number, creation_log, last_updated, mirror, file, button) are excluded from the identifier column list.
+
+---
+
+## Delete an Item
+
+```json
+{
+  "parameters": {
+    "resource": "item",
+    "operation": "deleteItem",
+    "itemId": "8886337853"
+  }
+}
+```
+
+Works for both items and subitems — just pass the correct item ID.
+
+---
+
+## Duplicate an Item
+
+```json
+{
+  "parameters": {
+    "resource": "item",
+    "operation": "duplicateItem",
+    "boardId": "8886337654",
+    "itemId": "8886337925",
+    "withUpdates": true
+  }
+}
+```
+
+| Parameter | Key | Type | Default | Notes |
+|---|---|---|---|---|
+| Board | `boardId` | options/string | — | Required |
+| Item | `itemId` | options/string | — | Item to copy |
+| With Updates | `withUpdates` | boolean | `false` | Include update posts in the copy |
+
+---
+
+## List Items in a Board
+
+```json
+{
+  "parameters": {
+    "resource": "item",
+    "operation": "listBoardItems",
+    "boardId": "7055564156",
+    "limit": 50,
+    "fetchAllColumns": true
+  }
+}
+```
+
+| Parameter | Key | Type | Default | Notes |
+|---|---|---|---|---|
+| Board | `boardId` | options/string | — | Required |
+| Limit | `limit` | number | `50` | `0` = all items |
+| Fetch All Columns | `fetchAllColumns` | boolean | `true` | All vs specific columns |
+| Column IDs | `columnIds` | string | — | Comma-separated when `fetchAllColumns: false` |
+
+---
+
+## List Items in a Group
+
+```json
+{
+  "parameters": {
+    "resource": "item",
+    "operation": "listGroupItems",
+    "boardId": "8886337654",
+    "groupId": "topics",
+    "limit": 50,
+    "fetchAllColumns": true
+  }
+}
+```
+
+| Parameter | Key | Type | Default | Notes |
+|---|---|---|---|---|
+| Board | `boardId` | options/string | — | Required |
+| Group ID | `groupId` | options/string | — | Required |
+| Limit | `limit` | number | `50` | `0` = all items |
+| Fetch All Columns | `fetchAllColumns` | boolean | `true` | All vs specific columns |
+| Column IDs | `columnIds` | string | — | Comma-separated when `fetchAllColumns: false` |
+
+---
+
+## Search Items by Filter
+
+```json
+{
+  "parameters": {
+    "resource": "item",
+    "operation": "searchItems",
+    "boardId": "8886337654",
+    "logicalOperator": "and",
+    "fetchColumnValues": true,
+    "fetchAllColumns": true,
+    "filterRules": {
+      "rule": [
+        {
+          "columnId": "status",
+          "compareAttribute": "text",
+          "operator": "any_of",
+          "compareValue": "Done"
+        },
+        {
+          "columnId": "text_mkq0ckhb",
+          "operator": "contains_text",
+          "compareValue": "keyword"
+        }
+      ]
+    },
+    "sortOptions": {
+      "sortBy": [
+        { "columnId": "name", "direction": "desc" }
+      ]
+    }
+  }
+}
+```
+
+| Parameter | Key | Type | Default | Notes |
+|---|---|---|---|---|
+| Board | `boardId` | options/string | — | Required |
+| Logical Operator | `logicalOperator` | options | `"and"` | `"and"` or `"or"` between rules |
+| Fetch Column Values | `fetchColumnValues` | boolean | `false` | Include column data in output |
+| Fetch All Columns | `fetchAllColumns` | boolean | `true` | All vs specific (when fetchColumnValues) |
+| Column IDs | `columnIds` | string | — | Comma-separated when `fetchAllColumns: false` |
+| Filter Rules | `filterRules` | fixedCollection | — | Array of rule objects |
+| Sort Options | `sortOptions` | fixedCollection | — | Array of sort objects |
+
+### Filter rule fields
+
+| Field | Key | Notes |
+|---|---|---|
+| Column | `columnId` | The column to filter on |
+| Compare Attribute | `compareAttribute` | Optional — use `"text"` for status labels |
+| Operator | `operator` | See operator list below |
+| Compare Value | `compareValue` | The value to compare against |
+
+### Operator options
+
+| Label | Value |
+|---|---|
+| Any Of | `any_of` |
+| Not Any Of | `not_any_of` |
+| Equals | `equals` |
+| Is Empty | `is_empty` |
+| Is Not Empty | `is_not_empty` |
+| Greater Than | `greater_than` |
+| Greater Than or Equal | `greater_than_or_equals` |
+| Less Than | `lower_than` |
+| Less Than or Equal | `lower_than_or_equal` |
+| Between | `between` |
+| Contains Text | `contains_text` |
+| Does Not Contain Text | `not_contains_text` |
+| Contains Terms | `contains_terms` |
+| Starts With | `starts_with` |
+| Ends With | `ends_with` |
+| Within the Next | `within_the_next` |
+| Within the Last | `within_the_last` |
+
+### Sort fields
+
+| Field | Key | Notes |
+|---|---|---|
+| Column | `columnId` | Column to sort by |
+| Direction | `direction` | `"asc"` or `"desc"` |
+
+---
+
+## List Item Subscribers
+
+```json
+{
+  "parameters": {
+    "resource": "item",
+    "operation": "listItemSubscribers",
+    "itemId": "8886337853"
+  }
+}
+```
+
+---
+
+## Get Item Activity Logs
+
+```json
+{
+  "parameters": {
+    "resource": "item",
+    "operation": "getItemActivityLogs",
+    "itemId": "8886337853",
+    "from": "2025-01-01T00:00:00",
+    "to": "2025-12-31T23:59:59",
+    "limit": 50
+  }
+}
+```
+
+| Parameter | Key | Type | Default | Notes |
+|---|---|---|---|---|
+| Item ID | `itemId` | string | — | Required |
+| From | `from` | dateTime | — | Inclusive start |
+| To | `to` | dateTime | — | Inclusive end |
+| Limit | `limit` | number | `50` | `0` = all logs |
+
+---
+
+## Upload Files to Column
+
+Uploads one or more binary files to a `file`-type column on an item.
+
+```json
+{
+  "parameters": {
+    "resource": "item",
+    "operation": "uploadItemFile",
+    "boardId": "8886337654",
+    "itemId": "8886337853",
+    "fileColumnId": "files_mkkqsvnw",
+    "binaryPropertyName": "data"
+  }
+}
+```
+
+| Parameter | Key | Type | Notes |
+|---|---|---|---|
+| Board | `boardId` | options/string | Required |
+| Item | `itemId` | options/string | Required |
+| File Column | `fileColumnId` | options | Only `file`-type columns appear here |
+| Binary Property | `binaryPropertyName` | string | n8n binary field name(s), comma-separated for multiple files |
+
+> The previous node in the workflow must output a binary file (e.g. from an HTTP Request, Read Binary File, or Google Drive node).
+
+---
+
+## Notes on Subitems
+
+- Set `isSubitem: true` on **createItem** and **createOrUpdateItem** to work with subitems
+- `boardId` always refers to the **parent board**, not the hidden "Subitems of …" board
+- The node automatically resolves the correct subitem board for column loading
+- If the board has no subitems yet, the column dropdown will be empty — create one manually first to populate it

--- a/docs/notification.md
+++ b/docs/notification.md
@@ -1,0 +1,71 @@
+# Notification Resource
+
+**Resource value:** `"notification"`
+
+Send in-app notifications to Monday.com users.
+
+---
+
+## Operations
+
+| Operation | Value | Description |
+|---|---|---|
+| Send Notification | `sendNotification` | Send a notification to a user (default) |
+
+---
+
+## Send Notification
+
+```json
+{
+  "parameters": {
+    "resource": "notification",
+    "operation": "sendNotification",
+    "notificationUserId": "45779868",
+    "notificationTargetId": "8886337853",
+    "notificationTargetType": "Project",
+    "notificationMessage": "You have a new task assigned to you"
+  }
+}
+```
+
+| Parameter | Key | Type | Notes |
+|---|---|---|---|
+| User ID | `notificationUserId` | string | Required — recipient's Monday.com user ID |
+| Target ID | `notificationTargetId` | string | Required — the item or post ID the notification links to |
+| Target Type | `notificationTargetType` | options | Required — `"Project"` (item) or `"Post"` (update) |
+| Message | `notificationMessage` | string | Required — notification text (plain text) |
+
+### Target Type values
+
+| Label | Value | Use when |
+|---|---|---|
+| Project | `"Project"` | Linking to a board item |
+| Post | `"Post"` | Linking to a specific update |
+
+---
+
+## Dynamic example
+
+Send a notification using data from a previous node:
+
+```json
+{
+  "parameters": {
+    "resource": "notification",
+    "operation": "sendNotification",
+    "notificationUserId": "={{ $json.assigneeId }}",
+    "notificationTargetId": "={{ $json.itemId }}",
+    "notificationTargetType": "Project",
+    "notificationMessage": "={{ 'Item updated: ' + $json.itemName }}"
+  }
+}
+```
+
+---
+
+## Notes
+
+- Notifications appear in the Monday.com bell icon for the recipient.
+- `notificationMessage` is plain text — HTML is not supported.
+- To notify multiple users, use an n8n **Loop** or **SplitInBatches** node upstream.

--- a/docs/query.md
+++ b/docs/query.md
@@ -1,0 +1,177 @@
+# Query Resource & Download File
+
+This file covers two simple resources that don't fit under the standard board/item model.
+
+---
+
+## Query Resource
+
+**Resource value:** `"query"`
+
+Run raw Monday.com GraphQL queries or mutations directly. Use this when no built-in operation covers your need.
+
+### Operation: Run API
+
+**Operation value:** `"query"`
+
+```json
+{
+  "parameters": {
+    "resource": "query",
+    "operation": "query",
+    "runQuery": "{ boards(limit: 5) { id name } }",
+    "apiVersion": "2026-01",
+    "includePagination": false
+  }
+}
+```
+
+| Parameter | Key | Type | Default | Notes |
+|---|---|---|---|---|
+| Query | `runQuery` | string | — | Full GraphQL query or mutation text |
+| API Version | `apiVersion` | string | `"2026-01"` | Monday.com API version string |
+| Include Pagination | `includePagination` | boolean | `false` | Auto-paginate across all pages |
+| Pagination Type | `paginationType` | options | `"cursor"` | `"cursor"` or `"page"` — visible when `includePagination: true` |
+
+---
+
+### Pagination
+
+When `includePagination: true`, the node automatically detects the pagination pattern in your query and fetches all pages.
+
+**Page-based query (boards, users, etc.):**
+```json
+{
+  "parameters": {
+    "resource": "query",
+    "operation": "query",
+    "runQuery": "{ boards(limit: 100, page: 1) { id name } }",
+    "includePagination": true,
+    "paginationType": "page"
+  }
+}
+```
+
+**Cursor-based query (items_page):**
+```json
+{
+  "parameters": {
+    "resource": "query",
+    "operation": "query",
+    "runQuery": "{ boards(ids: [8886337654]) { items_page(limit: 100) { cursor items { id name } } } }",
+    "includePagination": true,
+    "paginationType": "cursor"
+  }
+}
+```
+
+> Always include a `limit` parameter in your query — pagination will not work without it. The Monday.com API has different max limits per object type (boards: 100, items: 500, users: 100). Check the [Monday.com API docs](https://developer.monday.com/api-reference) for the current limits.
+
+---
+
+### Common query examples
+
+**Get specific columns from an item:**
+```graphql
+{
+  items(ids: ["8886337853"]) {
+    id
+    name
+    column_values(ids: ["status", "date4", "person"]) {
+      id
+      text
+      value
+    }
+  }
+}
+```
+
+**Get file column asset URLs:**
+```graphql
+{
+  items(ids: [8020743997]) {
+    column_values(ids: "files_mkkqsvnw") {
+      value
+    }
+  }
+}
+```
+
+**Create an item via mutation:**
+```graphql
+mutation {
+  create_item(
+    board_id: 8886337654,
+    group_id: "topics",
+    item_name: "Created via raw query"
+  ) {
+    id
+    name
+  }
+}
+```
+
+**Update a column value via mutation:**
+```graphql
+mutation {
+  change_simple_column_value(
+    board_id: 8886337654,
+    item_id: 8886337853,
+    column_id: "status",
+    value: "Done"
+  ) {
+    id
+  }
+}
+```
+
+---
+
+## Download File Resource
+
+**Resource value:** `"downloadFile"`
+
+Download a file asset from Monday.com by its asset ID. The output is a binary file that can be passed to other nodes (e.g. save to Google Drive, send via email).
+
+### Operation: Download File
+
+**Operation value:** `"downloadFile"`
+
+```json
+{
+  "parameters": {
+    "resource": "downloadFile",
+    "operation": "downloadFile",
+    "fileId": "123456789"
+  }
+}
+```
+
+| Parameter | Key | Type | Notes |
+|---|---|---|---|
+| Asset ID | `fileId` | string | Required — the Monday.com asset ID |
+
+### How to get an Asset ID
+
+Asset IDs appear in the `value` of a `file`-type column. Use the **Query** resource to fetch it:
+
+```graphql
+{
+  items(ids: ["8886337853"]) {
+    column_values(ids: ["files_mkkqsvnw"]) {
+      value
+    }
+  }
+}
+```
+
+The `value` JSON will contain something like:
+```json
+{
+  "files": [
+    { "assetId": 123456789, "name": "report.pdf", "url": "https://..." }
+  ]
+}
+```
+
+Pass `assetId` into the `fileId` field of this operation.

--- a/docs/team.md
+++ b/docs/team.md
@@ -1,0 +1,141 @@
+# Team Resource
+
+**Resource value:** `"team"`
+
+Manage Monday.com teams: list, get, create, delete, and manage team membership.
+
+---
+
+## Operations
+
+| Operation | Value | Description |
+|---|---|---|
+| List Teams | `listTeams` | List all teams (default) |
+| Get a Team | `getTeam` | Retrieve a specific team's details |
+| Create a Team | `createTeam` | Create a new team |
+| Delete a Team | `deleteTeam` | Delete a team |
+| Add Users to Team | `addUsersToTeam` | Add members to a team |
+| Remove Users From Team | `removeUsersFromTeam` | Remove members from a team |
+
+---
+
+## List Teams
+
+```json
+{
+  "parameters": {
+    "resource": "team",
+    "operation": "listTeams"
+  }
+}
+```
+
+No additional parameters. Returns all teams in the account.
+
+---
+
+## Get a Team
+
+```json
+{
+  "parameters": {
+    "resource": "team",
+    "operation": "getTeam",
+    "team": "750422"
+  }
+}
+```
+
+| Parameter | Key | Type | Notes |
+|---|---|---|---|
+| Team | `team` | options/string | Required — team ID |
+
+---
+
+## Create a Team
+
+```json
+{
+  "parameters": {
+    "resource": "team",
+    "operation": "createTeam",
+    "teamName": "Engineering",
+    "isGuest": false,
+    "userIds": ["62818631", "45779868"],
+    "allowEmptyTeam": false
+  }
+}
+```
+
+| Parameter | Key | Type | Default | Notes |
+|---|---|---|---|---|
+| Team Name | `teamName` | string | — | Required |
+| Is Guest | `isGuest` | boolean | `false` | Mark as a guest team |
+| Users | `userIds` | multiOptions | — | Initial team members |
+| Allow Empty Team | `allowEmptyTeam` | boolean | `false` | Allow creating the team with no initial members |
+
+---
+
+## Delete a Team
+
+```json
+{
+  "parameters": {
+    "resource": "team",
+    "operation": "deleteTeam",
+    "teamId": "1228038"
+  }
+}
+```
+
+| Parameter | Key | Type | Notes |
+|---|---|---|---|
+| Team ID | `teamId` | string | Required — use the raw ID string, not the dropdown |
+
+---
+
+## Add Users to Team
+
+```json
+{
+  "parameters": {
+    "resource": "team",
+    "operation": "addUsersToTeam",
+    "teamIds": "1228036",
+    "userIds": ["35597267", "45779868"]
+  }
+}
+```
+
+| Parameter | Key | Type | Notes |
+|---|---|---|---|
+| Team Name | `teamIds` | options/string | Required — target team |
+| Users | `userIds` | multiOptions | Required — users to add |
+
+---
+
+## Remove Users From Team
+
+```json
+{
+  "parameters": {
+    "resource": "team",
+    "operation": "removeUsersFromTeam",
+    "teamIds": "1228038",
+    "userIds": ["62818632"]
+  }
+}
+```
+
+| Parameter | Key | Type | Notes |
+|---|---|---|---|
+| Team Name | `teamIds` | options/string | Required — target team |
+| Users | `userIds` | multiOptions | Required — users to remove |
+
+---
+
+## Notes
+
+- `teamIds` (for add/remove users) is the **team ID as a string**, sourced from the team dropdown. Despite the plural name, it accepts a single team.
+- `teamId` (for delete) uses a plain string input — type the ID directly or use an expression.
+- To find team IDs, use **List Teams** first and note the `id` in the output.

--- a/docs/update.md
+++ b/docs/update.md
@@ -1,0 +1,199 @@
+# Update Resource
+
+**Resource value:** `"update"`
+
+Updates are the comment/post thread on a Monday.com item. This resource lets you list, create, edit, delete, pin, and attach files to updates.
+
+---
+
+## Operations
+
+| Operation | Value | Description |
+|---|---|---|
+| List Updates in an Item | `listUpdates` | Fetch all updates for an item (default) |
+| Create | `createUpdate` | Post a new update |
+| Update | `updateUpdate` | Edit an existing update |
+| Delete | `deleteUpdate` | Remove an update |
+| Pin | `pinUpdate` | Pin an update to the top |
+| Duplicate | `duplicateUpdate` | Duplicate an existing update |
+| Upload files to update | `uploadFile` | Attach binary files to an update |
+
+---
+
+## List Updates in an Item
+
+```json
+{
+  "parameters": {
+    "resource": "update",
+    "operation": "listUpdates",
+    "itemId": "8898396217",
+    "limit": 50,
+    "fromDate": "",
+    "toDate": ""
+  }
+}
+```
+
+| Parameter | Key | Type | Default | Notes |
+|---|---|---|---|---|
+| Item ID | `itemId` | string | — | Required |
+| Limit | `limit` | number | `50` | Max updates to return; `0` = all |
+| From Date | `fromDate` | dateTime | — | Filter: created on or after this date |
+| To Date | `toDate` | dateTime | — | Filter: created on or before this date |
+
+---
+
+## Create an Update
+
+Post a new update to an item's thread. Supports HTML content, replies, pinning, and binary attachments.
+
+```json
+{
+  "parameters": {
+    "resource": "update",
+    "operation": "createUpdate",
+    "itemId": "8886337853",
+    "bodyContent": "<p>Posted via n8n</p>",
+    "isReply": false,
+    "pinToTop": false,
+    "attachmentsUpdate": ""
+  }
+}
+```
+
+| Parameter | Key | Type | Default | Notes |
+|---|---|---|---|---|
+| Item ID | `itemId` | string | — | Required — item to post on |
+| Body Content | `bodyContent` | string | — | HTML content of the update |
+| Is Reply | `isReply` | boolean | `false` | Post as a reply to another update |
+| Update ID To Reply | `updateId` | string | — | Required when `isReply: true` |
+| Pin Update to Top | `pinToTop` | boolean | `false` | Pin this update immediately (not available for replies) |
+| Attachments | `attachmentsUpdate` | string | — | Comma-separated binary property names |
+
+**Reply to an existing update:**
+```json
+{
+  "parameters": {
+    "resource": "update",
+    "operation": "createUpdate",
+    "itemId": "8886337853",
+    "bodyContent": "<p>This is a reply</p>",
+    "isReply": true,
+    "updateId": "4024728517"
+  }
+}
+```
+
+**With a file attachment:**
+```json
+{
+  "parameters": {
+    "resource": "update",
+    "operation": "createUpdate",
+    "itemId": "8886337853",
+    "bodyContent": "<p>See attached file</p>",
+    "isReply": false,
+    "attachmentsUpdate": "data"
+  }
+}
+```
+
+> `bodyContent` supports standard HTML tags: `<p>`, `<b>`, `<i>`, `<ul>`, `<li>`, etc.
+
+---
+
+## Update an Update
+
+Edit the body of an existing update.
+
+```json
+{
+  "parameters": {
+    "resource": "update",
+    "operation": "updateUpdate",
+    "updateId": "4024728517",
+    "bodyContent": "<p>Edited via n8n</p>",
+    "attachmentsUpdate": ""
+  }
+}
+```
+
+| Parameter | Key | Type | Notes |
+|---|---|---|---|
+| Update ID | `updateId` | string | Required |
+| Body Content | `bodyContent` | string | New HTML content to replace the existing body |
+| Attachments | `attachmentsUpdate` | string | Comma-separated binary property names |
+
+---
+
+## Delete an Update
+
+```json
+{
+  "parameters": {
+    "resource": "update",
+    "operation": "deleteUpdate",
+    "updateId": "4024728517"
+  }
+}
+```
+
+| Parameter | Key | Type | Notes |
+|---|---|---|---|
+| Update ID | `updateId` | string | Required |
+
+---
+
+## Pin an Update
+
+Pins an update to the top of the item's update thread.
+
+```json
+{
+  "parameters": {
+    "resource": "update",
+    "operation": "pinUpdate",
+    "itemId": "8886337853",
+    "updateId": "4024728517"
+  }
+}
+```
+
+| Parameter | Key | Type | Notes |
+|---|---|---|---|
+| Item ID | `itemId` | string | Required — the item that owns the update |
+| Update ID | `updateId` | string | Required — the update to pin |
+
+---
+
+## Upload Files to an Update
+
+Attaches binary files from previous nodes to an existing update.
+
+```json
+{
+  "parameters": {
+    "resource": "update",
+    "operation": "uploadFile",
+    "updateId": "4024728517",
+    "attachmentsUpdate": "data"
+  }
+}
+```
+
+| Parameter | Key | Type | Notes |
+|---|---|---|---|
+| Update ID | `updateId` | string | Required |
+| Attachments | `attachmentsUpdate` | string | Comma-separated binary property names from the input |
+
+> A previous node must produce binary output (e.g. HTTP Request, Read Binary File, Google Drive download).  
+> Multiple files: `"attachmentsUpdate": "file1, file2, file3"`
+
+---
+
+## Tips
+
+- Update IDs are returned in the output of `listUpdates` and `createUpdate` — pipe them using expressions like `"={{ $json.id }}"`.
+- HTML content is supported in `bodyContent` — wrap text in `<p>` tags for proper formatting in Monday.
+- `pinToTop` is only available when `isReply: false`. Replies cannot be pinned.

--- a/docs/user.md
+++ b/docs/user.md
@@ -1,0 +1,55 @@
+# User Resource
+
+**Resource value:** `"user"`
+
+Read user information from the Monday.com account.
+
+---
+
+## Operations
+
+| Operation | Value | Description |
+|---|---|---|
+| List Users | `listUsers` | List all users in the account (default) |
+| Get a User | `getUser` | Retrieve specific users by ID |
+
+---
+
+## List Users
+
+```json
+{
+  "parameters": {
+    "resource": "user",
+    "operation": "listUsers"
+  }
+}
+```
+
+No additional parameters. Returns all users in the account.
+
+---
+
+## Get a User
+
+```json
+{
+  "parameters": {
+    "resource": "user",
+    "operation": "getUser",
+    "userIds": ["45779868", "35597267"]
+  }
+}
+```
+
+| Parameter | Key | Type | Notes |
+|---|---|---|---|
+| Users | `userIds` | multiOptions | One or more user IDs to retrieve |
+
+---
+
+## Notes
+
+- User IDs are referenced throughout the other resources (People columns, board subscribers, team members, notifications). Use **List Users** to discover IDs.
+- `userIds` is a multi-select — you can pass multiple IDs in a single call.
+- To use a dynamic user ID from a previous node: `"userIds": ["={{ $json.userId }}"]`

--- a/docs/webhook.md
+++ b/docs/webhook.md
@@ -1,0 +1,199 @@
+# Worktables Webhook Node
+
+**Node type:** `@worktables/n8n-nodes-worktables.mondayWebhook`  
+**Kind:** Trigger node  
+**Credential:** `WorktablesApi` (optional — needed only when **Get Item After Event** is enabled)
+
+Listens for Monday.com webhook events and triggers the workflow when an event arrives. Can optionally fetch the full item from the API after receiving the event.
+
+---
+
+## How Monday.com Webhooks Work
+
+1. You register a webhook URL in Monday.com pointing to the n8n webhook path
+2. Monday.com sends a POST request to that URL when the subscribed event fires
+3. This node receives the payload and passes it to the workflow
+
+Monday.com also sends a **challenge request** when a webhook is first registered. The node handles this automatically — it responds to the challenge and does not trigger the workflow.
+
+---
+
+## Parameters
+
+| Parameter | Key | Type | Default | Description |
+|---|---|---|---|---|
+| Get Item After Event | `getItemAfterEvent` | boolean | `false` | Fetch the full item from Monday after receiving the event |
+| Is Subitem | `isSubitem` | boolean | `false` | Treat the item as a subitem when fetching |
+| Fetch Subitems | `fetchSubitems` | boolean | `false` | Include child subitems in the response (when not a subitem) |
+| Fetch Parent Item | `fetchParentItem` | boolean | `false` | Include the parent item in the response (when a subitem) |
+| Fetch All Columns | `fetchAllColumns` | boolean | `true` | Fetch all columns vs a specific subset |
+| Column IDs | `columnIds` | string | — | Comma-separated column IDs (when `fetchAllColumns: false`) |
+
+---
+
+## Configurations
+
+### Minimal — raw event pass-through
+
+The node passes the raw Monday.com webhook payload directly to the workflow. No API call is made.
+
+```json
+{
+  "parameters": {},
+  "type": "@worktables/n8n-nodes-worktables.mondayWebhook",
+  "typeVersion": 1,
+  "webhookId": "a778ebae-95c3-4f05-ad86-0ada346025a1"
+}
+```
+
+---
+
+### With item fetch (all columns)
+
+After receiving the event the node calls the Monday.com API to retrieve the full item and merges it into the output.
+
+```json
+{
+  "parameters": {
+    "getItemAfterEvent": true,
+    "isSubitem": false,
+    "fetchSubitems": false,
+    "fetchAllColumns": true
+  },
+  "type": "@worktables/n8n-nodes-worktables.mondayWebhook",
+  "typeVersion": 1,
+  "webhookId": "a778ebae-95c3-4f05-ad86-0ada346025a1",
+  "credentials": {
+    "WorktablesApi": {
+      "id": "<credential-id>",
+      "name": "<credential-name>"
+    }
+  }
+}
+```
+
+---
+
+### With item fetch (specific columns)
+
+```json
+{
+  "parameters": {
+    "getItemAfterEvent": true,
+    "isSubitem": false,
+    "fetchSubitems": false,
+    "fetchAllColumns": false,
+    "columnIds": "status, date4, person"
+  },
+  "type": "@worktables/n8n-nodes-worktables.mondayWebhook",
+  "typeVersion": 1,
+  "webhookId": "a778ebae-95c3-4f05-ad86-0ada346025a1",
+  "credentials": {
+    "WorktablesApi": { "id": "...", "name": "..." }
+  }
+}
+```
+
+---
+
+### Subitem event with parent item
+
+```json
+{
+  "parameters": {
+    "getItemAfterEvent": true,
+    "isSubitem": true,
+    "fetchParentItem": true,
+    "fetchAllColumns": true
+  },
+  "type": "@worktables/n8n-nodes-worktables.mondayWebhook",
+  "typeVersion": 1,
+  "webhookId": "a778ebae-95c3-4f05-ad86-0ada346025a1",
+  "credentials": {
+    "WorktablesApi": { "id": "...", "name": "..." }
+  }
+}
+```
+
+---
+
+## Output
+
+### Raw mode (`getItemAfterEvent: false`)
+
+The output is the raw Monday.com webhook payload. Structure varies by event type. Example for a column change:
+
+```json
+{
+  "event": {
+    "type": "update_column_value",
+    "userId": 45779868,
+    "originalTriggerUuid": null,
+    "boardId": 8886337654,
+    "groupId": "topics",
+    "pulseId": 8886337853,
+    "pulseName": "Item Name",
+    "columnId": "status",
+    "columnType": "color",
+    "columnTitle": "Status",
+    "value": { "label": { "index": 1, "text": "Done" } },
+    "previousValue": { "label": { "index": 0, "text": "Working on it" } },
+    "changedAt": 1700000000.0
+  }
+}
+```
+
+### With item fetch (`getItemAfterEvent: true`)
+
+The raw event payload is merged with a formatted `item` object:
+
+```json
+{
+  "event": { ... },
+  "item": {
+    "id": "8886337853",
+    "name": "Item Name",
+    "url": "https://monday.com/boards/...",
+    "created_at": "2025-01-01T00:00:00Z",
+    "updated_at": "2025-01-02T00:00:00Z",
+    "board": { "id": "8886337654" },
+    "group": {
+      "id": "topics",
+      "title": "Topics",
+      "color": "#579bfc",
+      "position": "0"
+    },
+    "column_values": {
+      "status": { "type": "color",  "value": { "index": 1 }, "text": "Done" },
+      "date4":  { "type": "date",   "value": { "date": "2025-06-01" }, "text": "2025-06-01" },
+      "person": { "type": "people", "value": { "personsAndTeams": [...] }, "text": "Alice" }
+    },
+    "subitems": []
+  }
+}
+```
+
+If the item cannot be found (deleted or inaccessible), `item` will be `null` and the raw event body is still returned.
+
+---
+
+## Item ID resolution
+
+The node tries to extract the item ID from the event payload using these fields in order:
+
+1. `body.event.pulseId`
+2. `body.event.itemId`
+3. `body.event.entityId`
+4. `body.pulseId`
+5. `body.itemId`
+
+If none are present, the raw payload is returned without fetching.
+
+---
+
+## Tips
+
+- Use **raw mode** when you only need the event data (e.g. to capture the changed value and old value).
+- Use **Get Item After Event** when you need a consistent view of the full item state after the change.
+- The `item` field in the output has the same column_values format as the **Get an Item** operation — see [item.md](./item.md) for the output shape.
+- If you receive many events rapidly, the item fetch adds one API call per event. Consider raw mode + a separate **Get an Item** node downstream if you need to rate-limit.


### PR DESCRIPTION
## Summary

- Add `docs/` directory with per-resource markdown files: `board.md`, `item.md`, `update.md`, `team.md`, `user.md`, `notification.md`, `query.md`, `webhook.md`, `column-values.md`
- Add `docs/README.md` with node overview, credential setup, tips & tricks, and common pitfalls
- Add `AGENTS.md` at project root with instructions for AI agents to keep documentation in sync with node changes

## Test plan

- [ ] All links between doc files resolve correctly
- [ ] JSON examples in each file are valid JSON
- [ ] Operations tables match the actual operations defined in `Worktables.node.ts` and `MondayWebhook.node.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)